### PR TITLE
Maintain compatibility with Leaflet 0.7

### DIFF
--- a/NonTiledLayer.WMS.js
+++ b/NonTiledLayer.WMS.js
@@ -26,7 +26,7 @@ L.NonTiledLayer.WMS = L.NonTiledLayer.extend({
 		// all keys that are not NonTiledLayer options go to WMS params
 		for (var i in options) {
 			if (!L.NonTiledLayer.prototype.options.hasOwnProperty(i) && 
-                !L.Layer.prototype.options.hasOwnProperty(i)) {
+                !(L.Layer && L.Layer.prototype.options.hasOwnProperty(i))) {
 				wmsParams[i] = options[i];
 			}
 		}

--- a/NonTiledLayer.js
+++ b/NonTiledLayer.js
@@ -1,7 +1,7 @@
 /*
  * L.NonTiledLayer is an addon for leaflet which renders dynamic image overlays
  */
-L.NonTiledLayer = L.Layer.extend({
+L.NonTiledLayer = (L.Layer || L.Class).extend({
     includes: L.Mixin.Events,
     options: {
         attribution: '',
@@ -45,6 +45,19 @@ L.NonTiledLayer = L.Layer.extend({
         this._currentImage = this._initImage();
 
         this._update();
+    },
+
+    getPane: function(){
+        if (L.Layer){
+            return L.Layer.prototype.getPane.call(this);
+        }
+        if (this.options.pane) {
+            this._pane = this.options.pane;
+        }
+        else {
+            this._pane = this._map.getPanes().overlayPane;
+        }
+        return this._pane;
     },
 
     onRemove: function (map) {


### PR DESCRIPTION
Current version of Leaflet.NonTiledLayer is only compatible with 1.0 version of Leaflet (which is currently in Release Candidate stage). With these changes, the plugin should be compatible with the current stable version (0.7.7) and the new version.
