### PR TITLE
Add CrossOrigin attribute to images

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -43,6 +43,7 @@ or use the latest build at https://unpkg.com/leaflet.nontiledlayer/dist/
 * *errorImageUrl* - the url of the image displayed when the layer fails to load (invalid request or server error). Default: 1px transparent gif ```data:image/gif;base64,R0lGODlhAQABAHAAACH5BAUAAAAALAAAAAABAAEAAAICRAEAOw==```
 * *useCanvas* - use the canvas to render the images, fixes flickering issues with Firefox, doesn't work on IE8. Setting it to ```undefined``` will use canvas, if available. Default: ```undefined``` 
 * *detectRetina* - doubles the actual image size requested, if the Browser is in retina mode. Default: ```false```
+* *crossOrigin* - enables cross origin capabilities. Valid values are 'anonymous' and 'use-credentials'. Default: ```undefined```
 
 The pane and zIndex properties allow to fine-tune the layer ordering. For example, it is possible to insert a NonTiledLayer between two layers the tilePane, like the labels [here](http://176.95.37.29/coveragedemo/), or on top of the vector shapes, like the labels [here](https://ptv-logistics.github.io/fl-labs/) or [here](https://api-eu-test.cloud.ptvgroup.com/CodeSampleBrowser/index.jsp#samples/data-rendering-geoJson/view).
 

--- a/src/NonTiledLayer.js
+++ b/src/NonTiledLayer.js
@@ -188,6 +188,10 @@ L.NonTiledLayer = (L.Layer || L.Class).extend({
 		_canvas._image = new Image();
 		this._ctx = _canvas.getContext('2d');
 
+		if (!!this.options.crossOrigin) {
+			_canvas._image.crossOrigin = this.options.crossOrigin;
+		}
+
 		if (this._map.options.zoomAnimation && L.Browser.any3d) {
 			L.DomUtil.addClass(_canvas, 'leaflet-zoom-animated');
 		} else {


### PR DESCRIPTION
Hey guys, 

I've added an option to add the crossOrigin attribute to the loaded images, just like Leaflet.TiledLayers offers and does it.

Why is it useful?

If you want to use libraries like html2canvas or dom-to-image to create a screenshot of the map, the canvas cannot be "tainted". But loading images on the canvas without the cross origin attribute set, will set the canvas "tainted".

The problem is explained quite well over here https://medium.com/@albertogasparin/manipulating-cross-origin-images-with-html-canvas-1e3e8780964c

Would love it if you include the merge request, as we have to hack the fix in in our project.