### PR TITLE
Include Leaflet as a peer dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,9 +8,6 @@
       "name": "leaflet.nontiledlayer",
       "version": "1.0.9",
       "license": "ISC",
-      "dependencies": {
-        "leaflet": "^1.6.0"
-      },
       "devDependencies": {
         "@rollup/plugin-commonjs": "^19.0.0",
         "@rollup/plugin-node-resolve": "^13.0.0",
@@ -25,6 +22,9 @@
         "rollup-plugin-terser": "^7.0.2",
         "tslib": "^2.2.0",
         "typescript": "^4.3.2"
+      },
+      "peerDependencies": {
+        "leaflet": "^1.7.1"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -2225,7 +2225,8 @@
     "node_modules/leaflet": {
       "version": "1.7.1",
       "resolved": "https://registry.npmjs.org/leaflet/-/leaflet-1.7.1.tgz",
-      "integrity": "sha512-/xwPEBidtg69Q3HlqPdU3DnrXQOvQU/CCHA1tcDQVzOwm91YMYaILjNp7L4Eaw5Z4sOYdbBz6koWyibppd8Zqw=="
+      "integrity": "sha512-/xwPEBidtg69Q3HlqPdU3DnrXQOvQU/CCHA1tcDQVzOwm91YMYaILjNp7L4Eaw5Z4sOYdbBz6koWyibppd8Zqw==",
+      "peer": true
     },
     "node_modules/levn": {
       "version": "0.4.1",
@@ -5100,7 +5101,8 @@
     "leaflet": {
       "version": "1.7.1",
       "resolved": "https://registry.npmjs.org/leaflet/-/leaflet-1.7.1.tgz",
-      "integrity": "sha512-/xwPEBidtg69Q3HlqPdU3DnrXQOvQU/CCHA1tcDQVzOwm91YMYaILjNp7L4Eaw5Z4sOYdbBz6koWyibppd8Zqw=="
+      "integrity": "sha512-/xwPEBidtg69Q3HlqPdU3DnrXQOvQU/CCHA1tcDQVzOwm91YMYaILjNp7L4Eaw5Z4sOYdbBz6koWyibppd8Zqw==",
+      "peer": true
     },
     "levn": {
       "version": "0.4.1",

--- a/package.json
+++ b/package.json
@@ -32,8 +32,8 @@
     "url": "https://github.com/ptv-logistics/Leaflet.NonTiledLayer/issues"
   },
   "homepage": "https://github.com/ptv-logistics/Leaflet.NonTiledLayer",
-  "dependencies": {
-    "leaflet": "^1.6.0"
+  "peerDependencies": {
+    "leaflet": "^1.7.1"
   },
   "devDependencies": {
     "@rollup/plugin-commonjs": "^19.0.0",


### PR DESCRIPTION
This change includes `leaflet` as a peer dependency instead of a regular dependency. This forces the user to install the dependency themselves instead of having the provided version of the dependency automatically. This means that the user is free to install any version of `leaflet` as longs as it matches the same version range of the peer dependency.

More information about peer dependencies and the motivation behind it can be found [here](https://nodejs.org/es/blog/npm/peer-dependencies/).

I've marked this as a breaking change that should be introduced in a next major version.