### PR TITLE
Define 'nonTiledLayer' on global instead of module

### DIFF
--- a/src/NonTiledLayer.ts
+++ b/src/NonTiledLayer.ts
@@ -59,7 +59,8 @@ var NonTiledLayer = (L.Layer || L.Class).extend({
 
     this.getPane().appendChild(this._div);
 
-    var canvasSupported = !!window.HTMLCanvasElement;
+    var canvasSupported = typeof window !== 'undefined' && !!window.HTMLCanvasElement;
+
     if (typeof this.options.useCanvas === 'undefined') {
       this._useCanvas = canvasSupported;
     } else {
@@ -468,9 +469,11 @@ var NonTiledLayer = (L.Layer || L.Class).extend({
 
 });
 
-L.nonTiledLayer = function () {
-  return new NonTiledLayer();
-};
+if (typeof window !== 'undefined' && typeof (window as any).L !== 'undefined') {
+  (window as any).L.nonTiledLayer = function nonTiledLayer() {
+    return new NonTiledLayer();
+  };
+}
 
 /*
  * L.NonTiledLayer.WMS is used for putting WMS non tiled layers on the map.


### PR DESCRIPTION
This change prevents the default import from Leaflet (`L`) from being re-assigned, which is not allowed in ECMAScript modules. Instead the global on the window is detected, and if present the value is assigned there.

This change lays the groundwork so the library can be shipped in the ES module format as well.