### PR TITLE
Enable 'prefer-template' ESLint rule and fix issues

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -18,7 +18,6 @@
     "no-restricted-syntax": "off",
     "no-underscore-dangle": "off",
     "prefer-arrow-callback": "off",
-    "prefer-destructuring": "off",
-    "prefer-template": "off"
+    "prefer-destructuring": "off"
   }
 }

--- a/src/NonTiledLayer.ts
+++ b/src/NonTiledLayer.ts
@@ -258,8 +258,8 @@ const NonTiledLayer = L.Layer.extend({
       image.width = size.x;
       image.height = size.y;
     } else {
-      image.style.width = size.x + 'px';
-      image.style.height = size.y + 'px';
+      image.style.width = `${size.x}px`;
+      image.style.height = `${size.y}px`;
     }
   },
 
@@ -356,7 +356,7 @@ const NonTiledLayer = L.Layer.extend({
     height *= this._getImageScale();
 
     // create a key identifying the current request
-    this.key = '' + bounds.getNorthWest() + ', ' + bounds.getSouthEast() + ', ' + width + ', ' + height;
+    this.key = [bounds.getNorthWest(), bounds.getSouthEast(), width, height].join(', ');
 
     if (this.getImageUrl) {
       i.src = this.getImageUrl(bounds, width, height);


### PR DESCRIPTION
Depends on #122, which should be merged first. Introduces ES2015 syntax which is a breaking change.