### PR TITLE
Enable 'prefer-destructuring' ESLint rule and fix issues

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -17,7 +17,6 @@
     "no-param-reassign": "off",
     "no-restricted-syntax": "off",
     "no-underscore-dangle": "off",
-    "prefer-arrow-callback": "off",
-    "prefer-destructuring": "off"
+    "prefer-arrow-callback": "off"
   }
 }

--- a/src/NonTiledLayer.ts
+++ b/src/NonTiledLayer.ts
@@ -491,7 +491,7 @@ const NonTiledLayer = L.Layer.extend({
   },
 
   getImageUrl: function getImageUrl(bounds, width, height) {
-    const wmsParams = this.wmsParams;
+    const { wmsParams } = this;
 
     wmsParams.width = width;
     wmsParams.height = height;


### PR DESCRIPTION
Depends on #123, which should be merged first. Introduces ES2015 syntax which is a breaking change.