### PR TITLE
Enable 'prefer-arrow-callback' ESLint rule and fix issues

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -16,7 +16,6 @@
     "import/no-mutable-exports": "off",
     "no-param-reassign": "off",
     "no-restricted-syntax": "off",
-    "no-underscore-dangle": "off",
-    "prefer-arrow-callback": "off"
+    "no-underscore-dangle": "off"
   }
 }

--- a/src/NonTiledLayer.ts
+++ b/src/NonTiledLayer.ts
@@ -362,7 +362,7 @@ const NonTiledLayer = L.Layer.extend({
       i.src = this.getImageUrl(bounds, width, height);
       i.key = this.key;
     } else {
-      this.getImageUrlAsync(bounds, width, height, this.key, function callback(key, url, tag) {
+      this.getImageUrlAsync(bounds, width, height, this.key, (key, url, tag) => {
         i.key = key;
         i.src = url;
         i.tag = tag;


### PR DESCRIPTION
Depends on #124, which should be merged first. Introduces ES2015 syntax which is a breaking change.