### PR TITLE
Remove mutable exports from Leaflet namespace

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -13,7 +13,6 @@
     "airbnb-typescript/base"
   ],
   "rules": {
-    "import/no-mutable-exports": "off",
     "no-param-reassign": "off",
     "no-restricted-syntax": "off",
     "no-underscore-dangle": "off"

--- a/index.html
+++ b/index.html
@@ -67,7 +67,7 @@
         }).addTo(map);
 
         // add (non-tiled) label layer. Insert at tile pane
-        var labels = L.nonTiledLayer.wms(xMapWmsUrl, {
+        var labels = new L.NonTiledLayer.WMS(xMapWmsUrl, {
             maxZoom: 19,
             minZoom: 0,
             opacity: 1.0,
@@ -80,7 +80,7 @@
         }).addTo(map);
 
         // add pois. Default - insert at overlayPane
-        var poi = L.nonTiledLayer.wms(xMapWmsUrl, {
+        var poi = new L.NonTiledLayer.WMS(xMapWmsUrl, {
             maxZoom: 19,
             minZoom: 16,
             zIndex: 5, // setting a zIndex enforces the layer ordering after adding/removing multiple layers
@@ -92,7 +92,7 @@
         }).addTo(map);
 
         // add contours, on tile pane
-        var contour = L.nonTiledLayer.wms('https://ows.terrestris.de/osm/service', {
+        var contour = new L.NonTiledLayer.WMS('https://ows.terrestris.de/osm/service', {
             maxZoom: 19,
             minZoom: 4,
             zIndex: 2, // setting a zIndex enforces the layer ordering after adding/removing multiple layers
@@ -106,7 +106,7 @@
         }).addTo(map); 
 
         // insert airmass layer, at tile pane between background and labels
-        var airmass = L.nonTiledLayer.wms("https://eumetview.eumetsat.int/geoserv/wms", {
+        var airmass = new L.NonTiledLayer.WMS("https://eumetview.eumetsat.int/geoserv/wms", {
             maxZoom: 8,
             minZoom: 0,
             layers: 'meteosat:msg_eview',

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -7,7 +7,6 @@ import { terser } from 'rollup-plugin-terser';
 const outputConfig = {
   name: 'L.NonTiledLayer',
   format: 'umd',
-  interop: false,
   globals: {
     leaflet: 'L',
   },

--- a/src/NonTiledLayer.ts
+++ b/src/NonTiledLayer.ts
@@ -1,5 +1,4 @@
 import type { LayerOptions } from 'leaflet';
-import * as L from 'leaflet';
 import {
   bind,
   Bounds,
@@ -482,10 +481,6 @@ const NonTiledLayer = Layer.extend({
 
 });
 
-(L as any).nonTiledLayer = function nonTiledLayer() {
-  return new NonTiledLayer();
-};
-
 /*
  * L.NonTiledLayer.WMS is used for putting WMS non tiled layers on the map.
  */
@@ -564,9 +559,5 @@ const NonTiledLayer = Layer.extend({
     return this;
   },
 });
-
-(L as any).nonTiledLayer.wms = function nonTiledLayer(url, options) {
-  return new (NonTiledLayer as any).WMS(url, options);
-};
 
 export default NonTiledLayer;


### PR DESCRIPTION
Remove both `L.nonTiledLayer` and `L.nonTiledLayer.wms` from the Leaflet namespace.