### PR TITLE
Bugfix/polar projection support

### DIFF
--- a/src/NonTiledLayer.ts
+++ b/src/NonTiledLayer.ts
@@ -348,8 +348,10 @@ const NonTiledLayer = Layer.extend({
     const pix2 = this._map.latLngToContainerPoint(bounds.getSouthEast());
 
     // get pixel size
-    let width = pix2.x - pix1.x;
-    let height = pix2.y - pix1.y;
+    // Use Math.abs() to handle polar projections where the axes may be inverted
+    // relative to standard projections, causing pix2.y < pix1.y
+    let width = Math.abs(pix2.x - pix1.x);
+    let height = Math.abs(pix2.y - pix1.y);
 
     let i;
     if (this._useCanvas) {
@@ -547,9 +549,15 @@ const NonTiledLayer = Layer.extend({
     const nw = this._crs.project(bounds.getNorthWest());
     const se = this._crs.project(bounds.getSouthEast());
     const url = this._wmsUrl;
-    const bbox = (this._wmsVersion >= 1.3 && this._crs === CRS.EPSG4326
-      ? [se.y, nw.x, nw.y, se.x]
-      : [nw.x, se.y, se.x, nw.y]).join(',');
+    let bbox;
+    if (this._wmsVersion >= 1.3 && this._crs === CRS.EPSG4326) {
+      bbox = [se.y, nw.x, nw.y, se.x].join(',');
+    } else if (this._crs.code === "EPSG:3031") {
+      // Polar stereographic projections need minX,minY,maxX,maxY ordering
+      bbox = [nw.x, nw.y, se.x, se.y].join(',');
+    } else {
+      bbox = [nw.x, se.y, se.x, nw.y].join(',');
+    }
 
     return url + Util.getParamString(this.wmsParams, url, this.options.uppercase) + (this.options.uppercase ? '&BBOX=' : '&bbox=') + bbox;
   },

--- a/src/NonTiledLayer.ts
+++ b/src/NonTiledLayer.ts
@@ -548,16 +548,14 @@ const NonTiledLayer = Layer.extend({
 
     const nw = this._crs.project(bounds.getNorthWest());
     const se = this._crs.project(bounds.getSouthEast());
+		const minX = Math.min(nw.x, se.x);
+		const maxX = Math.max(nw.x, se.x);
+		const minY = Math.min(nw.y, se.y);
+		const maxY = Math.max(nw.y, se.y);
     const url = this._wmsUrl;
-    let bbox;
-    if (this._wmsVersion >= 1.3 && this._crs === CRS.EPSG4326) {
-      bbox = [se.y, nw.x, nw.y, se.x].join(',');
-    } else if (this._crs.code === "EPSG:3031") {
-      // Polar stereographic projections need minX,minY,maxX,maxY ordering
-      bbox = [nw.x, nw.y, se.x, se.y].join(',');
-    } else {
-      bbox = [nw.x, se.y, se.x, nw.y].join(',');
-    }
+    const bbox = (this._wmsVersion >= 1.3 && this._crs === CRS.EPSG4326
+      ? [minY, minX, maxY, maxX]
+      : [minX, minY, maxX, maxY]).join(',');
 
     return url + Util.getParamString(this.wmsParams, url, this.options.uppercase) + (this.options.uppercase ? '&BBOX=' : '&bbox=') + bbox;
   },


### PR DESCRIPTION
Fixes rendering issues with WMS layers in polar coordinate systems (e.g. EPSG:3031 Antarctic Polar Stereographic) by making bbox calculations CRS-agnostic.

## Problem
Leaflet's bounds.getNorthWest() and bounds.getSouthEast() methods assume standard geographic coordinate systems where "northwest" is always top-left and "southeast" is always bottom-right. However, in polar projections, these coordinate relationships can be inverted:
- Northwest X may be greater than Southeast X
- Northwest Y may be greater than Southeast Y

This caused two issues:
1. Negative dimensions: Canvas width/height calculations (pix2.x - pix1.x, pix2.y - pix1.y) could produce negative values, breaking rendering
2. Invalid WMS bbox parameters: The bbox sent to WMS servers would have min/max values swapped

## Solution
- Canvas dimensions: Wrap width/height calculations in Math.abs() to ensure positive values regardless of coordinate ordering
- WMS bbox: Calculate proper min/max bounds using Math.min() and Math.max() instead of assuming coordinate ordering, then construct bbox parameters correctly

## Testing
Tested with EPSG:3031 (Antarctic Polar Stereographic) and EPSG:3857 (Pseudo-Mercator).