### PR TITLE
Fix lint issues

### DIFF
--- a/src/NonTiledLayer.ts
+++ b/src/NonTiledLayer.ts
@@ -548,10 +548,10 @@ const NonTiledLayer = Layer.extend({
 
     const nw = this._crs.project(bounds.getNorthWest());
     const se = this._crs.project(bounds.getSouthEast());
-		const minX = Math.min(nw.x, se.x);
-		const maxX = Math.max(nw.x, se.x);
-		const minY = Math.min(nw.y, se.y);
-		const maxY = Math.max(nw.y, se.y);
+    const minX = Math.min(nw.x, se.x);
+    const maxX = Math.max(nw.x, se.x);
+    const minY = Math.min(nw.y, se.y);
+    const maxY = Math.max(nw.y, se.y);
     const url = this._wmsUrl;
     const bbox = (this._wmsVersion >= 1.3 && this._crs === CRS.EPSG4326
       ? [minY, minX, maxY, maxX]


### PR DESCRIPTION
Quick PR to fix the lint issues that came up in [the latest CI pipeline run](https://github.com/ptv-logistics/Leaflet.NonTiledLayer/actions/runs/20128280921) from merging my previous PR #465.

I did a quick `npm run lint` which uncovered the following:
src\NonTiledLayer.ts
  551:1    error  Unexpected tab character                           no-tabs
  551:1    error  Expected indentation of 4 spaces but found 2 tabs  @typescript-eslint/indent
  552:1    error  Unexpected tab character                           no-tabs
  552:1    error  Expected indentation of 4 spaces but found 2 tabs  @typescript-eslint/indent
  553:1    error  Unexpected tab character                           no-tabs
  553:1    error  Expected indentation of 4 spaces but found 2 tabs  @typescript-eslint/indent
  554:1    error  Unexpected tab character                           no-tabs
  554:1    error  Expected indentation of 4 spaces but found 2 tabs  @typescript-eslint/indent

Then I fixed it with a `npm run lint -- --fix`